### PR TITLE
update some typos; clearly print the path for install

### DIFF
--- a/core.py
+++ b/core.py
@@ -72,7 +72,7 @@ class HackingTool(object):
         for index, option in enumerate(self.OPTIONS):
             print(f"[{index + 1}] {option[0]}")
         if self.PROJECT_URL:
-            print(f"[{98}] Open project page}")
+            print(f"[{98}] Open project page")
         print(f"[{99}] Back to {parent.TITLE if parent is not None else 'Exit'}")
         option_index = input("Select an option : ")
         try:

--- a/core.py
+++ b/core.py
@@ -65,17 +65,15 @@ class HackingTool(object):
             desc += '\n\t[*] '
             desc += self.PROJECT_URL
         os.system(f'echo "{desc}"|boxes -d boy | lolcat')
-        # print(desc)
 
     def show_options(self, parent = None):
         clear_screen()
         self.show_info()
         for index, option in enumerate(self.OPTIONS):
-            print("[{:2}] {}".format(index + 1, option[0]))
+            print(f"[{index + 1}] {option[0]}")
         if self.PROJECT_URL:
-            print("[{:2}] {}".format(98, "Open project page"))
-        print("[{:2}] {}".format(
-            99, ("Back to " + parent.TITLE) if parent is not None else "Exit"))
+            print(f"[{98}] Open project page}")
+        print(f"[{99}] Back to {parent.TITLE if parent is not None else 'Exit'}")
         option_index = input("Select an option : ")
         try:
             option_index = int(option_index)
@@ -162,9 +160,8 @@ class HackingToolsCollection(object):
         clear_screen()
         self.show_info()
         for index, tool in enumerate(self.TOOLS):
-            print("[{:2}] {}".format(index, tool.TITLE))
-        print("[{:2}] {}".format(
-            99, ("Back to " + parent.TITLE) if parent is not None else "Exit"))
+            print(f"[{index} {tool.TITLE}")
+        print(f"[{99}] Back to {parent.TITLE if parent is not None else 'Exit'}")
         tool_index = input("Choose a tool to proceed: ")
         try:
             tool_index = int(tool_index)

--- a/hackingtool.py
+++ b/hackingtool.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
                 print("""
                         [@] Set Path (All your tools will be installed in that directory)
                         [1] Manual 
-                        [2] Default
+                        [2] Defaultl
                 """)
                 choice = input("Z4nzu =>> ")
 

--- a/hackingtool.py
+++ b/hackingtool.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
                 os.system('clear')
                 # run.menu()
                 print("""
-                        [@] Set Path (All your tools will be install in that directory)
+                        [@] Set Path (All your tools will be installed in that directory)
                         [1] Manual 
                         [2] Default
                 """)
@@ -89,12 +89,12 @@ if __name__ == "__main__":
                     inpath = input("Enter Path (with Directory Name) >> ")
                     with open(fpath, "w") as f:
                         f.write(inpath)
-                    print("Successfully Path Set...!!")
+                    print(f"Successfully Set Path to: {inpath}")
                 elif choice == "2":
                     autopath = "/home/hackingtool/"
                     with open(fpath, "w") as f:
                         f.write(autopath)
-                    print(f"Your Default Path Is:- {autopath}")
+                    print(f"Your Default Path Is: {autopath}")
                     sleep(3)
                 else:
                     print("Try Again..!!")
@@ -111,12 +111,12 @@ if __name__ == "__main__":
         # If not Linux and probably Windows
         elif system() == "Windows":
             print(
-                "\033[91m Please Run This Tool In Debian System For Best Result " "\e[00m")
+                "\033[91m Please Run This Tool On A Debian System For Best Results " "\e[00m")
             sleep(2)
             webbrowser.open_new_tab("https://tinyurl.com/y522modc")
 
         else:
-            print("Please Check Your Sytem or Open new issue ...")
+            print("Please Check Your System or Open New Issue ...")
 
     except KeyboardInterrupt:
         print("\nExiting ..!!!")

--- a/hackingtool.py
+++ b/hackingtool.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
                 print("""
                         [@] Set Path (All your tools will be installed in that directory)
                         [1] Manual 
-                        [2] Defaultl
+                        [2] Default
                 """)
                 choice = input("Z4nzu =>> ")
 

--- a/tools/anonsurf.py
+++ b/tools/anonsurf.py
@@ -6,7 +6,7 @@ from core import HackingToolsCollection
 
 
 class AnonymouslySurf(HackingTool):
-    TITLE = "Anonmously Surf"
+    TITLE = "Anonymously Surf"
     DESCRIPTION = "It automatically overwrites the RAM when\n" \
                   "the system is shutting down and also change Ip."
     INSTALL_COMMANDS = [


### PR DESCRIPTION
fixed a couple of typos in hackingtool.py. also, print the installation path regardless of selected option (for clarity)