### PR TITLE
Install python3-pip, not python2-pip

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ if [ $choice == 1 ]; then
 	if [[ $? -eq 0 ]]; then
 	    echo -e ${BLUE}"[✔] Loading ... "
 	    sudo apt-get update && apt-get upgrade 
-	    sudo apt-get install python-pip
+	    sudo apt-get install python3-pip
 	    echo "[✔] Checking directories..."
 	    if [ -d "$INSTALL_DIR" ]; then
 	        echo "[!] A Directory hackingtool Was Found.. Do You Want To Replace It ? [y/n]:" ;


### PR DESCRIPTION
Fixes #186
Fixes #212
Fixes #213

Lines 61, 67, 69, 71, and 72 are using Python 3 or Python 3 pip so **let's install Python 3 pip**, not Python 2 pip.

Python 2 died 824 days ago on 1/1/2020 so it is often no longer available in modern operating systems.