### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,7 +43,7 @@ if [ $choice == 1 ]; then
 	if [[ $? -eq 0 ]]; then
 	    echo -e ${BLUE}"[✔] Loading ... "
 	    sudo apt-get update && apt-get upgrade 
-	    sudo apt-get install python-pip
+	    sudo apt-get install python3-pip
 	    echo "[✔] Checking directories..."
 	    if [ -d "$INSTALL_DIR" ]; then
 	        echo "[!] A Directory hackingtool Was Found.. Do You Want To Replace It ? [y/n]:" ;


### PR DESCRIPTION
install.sh now installs python3-pip instead of python-pip
Fixes https://github.com/Z4nzu/hackingtool/issues/186
Fixes https://github.com/Z4nzu/hackingtool/issues/212
Fixes https://github.com/Z4nzu/hackingtool/issues/213