### PR TITLE
Added Port Scanner that Works with Python 3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@
 - [Striker](https://github.com/s0md3v/Striker)
 - [SecretFinder (like API & etc)](https://github.com/m4ll0k/SecretFinder)
 - [Find Info Using Shodan](https://github.com/m4ll0k/Shodanfy.py)
-- [Port Scanner - rang3r](https://github.com/floriankunushevci/rang3r)
+- [Port Scanner - rang3r (Python 2.7)](https://github.com/floriankunushevci/rang3r)
+- [Port Scanner - Ranger Reloaded (Python 3+)](https://github.com/joeyagreco/ranger-reloaded)
 - [Breacher](https://github.com/s0md3v/Breacher)
 ### Wordlist Generator
 - [Cupp](https://github.com/Mebus/cupp.git)


### PR DESCRIPTION
The current port scanner (rang3r) is no longer supported (last updated 5 years ago) and runs on an outdated version of Python (2.7).

I rewrote this script with python 3.10 and added it as a Python 3+ option for port scanning.