### PR TITLE
Syntax Fix for older versions of python

### DIFF
--- a/hackingtool.py
+++ b/hackingtool.py
@@ -89,12 +89,12 @@ if __name__ == "__main__":
                     inpath = input("Enter Path (with Directory Name) >> ")
                     with open(fpath, "w") as f:
                         f.write(inpath)
-                    print(f"Successfully Set Path to: {inpath}")
+                    print("Successfully Set Path to: {}".format(inpath))
                 elif choice == "2":
                     autopath = "/home/hackingtool/"
                     with open(fpath, "w") as f:
                         f.write(autopath)
-                    print(f"Your Default Path Is: {autopath}")
+                    print("Your Default Path Is: {}".format(autopath))
                     sleep(3)
                 else:
                     print("Try Again..!!")


### PR DESCRIPTION

## This request is for issue: #273  

There can be a syntax errors for older versions of python (prior to 3.6 I think) therefore it may be better off that the syntax output is as such