### PR TITLE
Add Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM kalilinux/kali-rolling
+
+RUN apt-get update && \
+apt-get install -y git python3-pip figlet sudo;
+
+#Install packages dependencies
+RUN true && \
+apt-get install -y boxes php curl xdotool wget;
+
+WORKDIR /root/hackingtool
+COPY . .
+
+RUN true && \
+pip3 install -r requirement.txt;
+
+RUN true && \
+pip3 install lolcat boxes flask requests;
+
+RUN true && \
+ echo "/root/hackingtool/" > /home/hackingtoolpath.txt;
+
+EXPOSE 1-65535
+
+ENTRYPOINT ["python3", "/root/hackingtool/hackingtool.py"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![HitCount](http://hits.dwyl.com/Z4nzu/hackingtool.svg)](http://hits.dwyl.com/Z4nzu/hackingtool)
 ![](https://img.shields.io/badge/platform-Linux%20%7C%20KaliLinux%20%7C%20ParrotOs-blue)
 
-#### Install Kali Linux in WIndows10 Without VirtualBox [YOUTUBE](https://youtu.be/BsFhpIDcd9I)
+#### Install Kali Linux in WIndows10 Without VirtualBox [YOUTUBE](https://youtu.be/BsFhpIDcd9I) or use Docker
 
 ## Update Available V1.1.0 🚀 
 - [x] Added New Tools 
@@ -223,6 +223,20 @@
     sudo hackingtool
 
  After Following All Steps Just Type In Terminal **root@kaliLinux:~** **hackingtool**
+
+## Use image with Docker
+
+### Run in one click
+`docker run -it vgpastor/hackingtool`
+
+### Build locally
+`docker-compose build`
+
+`docker-compose run hackingtool`
+
+- If need open other ports you can edit the docker-compose.yml file
+- Volumes are mounted in the container to persist data and can share files between the host and the container
+
 
 #### Thanks to original Author of the tools used in hackingtool
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  hackingtool:
+    build: .
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+    volumes:
+      - .:/root/hackingtool
+    ports:
+      - 22:22


### PR DESCRIPTION
With this PR any users can try the software without need install them in his local instance.

Documentation are added to advise of this.

Additionally i recommend that the image are uploaded to Z4nzu/hackingtool Docker repository but, i don't have a problem to store the images.