### PR TITLE
fix: #334  

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,14 @@ if [ $choice == 1 ] || [ $choice == 2 ]; then
             sudo apt-get install python3-pip -y
         elif [ $choice == 2 ]; then # added arch linux support because of feature request #231
             sudo pacman -Suy
-            sudo pacman -S python-pip yay
+            sudo pacman -S python-pip
+	    sudo git clone https://aur.archlinux.org/yay-git.git 
+	    sudo chown -R $USER:$USER yay-git
+	    cd yay-git
+	    makepkg -si
+	    cd ..
+	    rm -rf yay-git
+	    
         fi
 
 	    echo "[✔] Checking directories..."


### PR DESCRIPTION
Issue in question: #334 
There is an issue about yay not being included in the arch default repositories which result in arch installation failure. The default install consists of cloning yay-git from Arch user repositories and continuing install from there. 
This fix is not tested extensively and I am not proficient in shellscript, 
so if anyone can test installation and make suggestions if necessary that would be great.


