### PR TITLE
Dockerfile: Use pip dependency resolver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,7 @@ WORKDIR /root/hackingtool
 COPY . .
 
 RUN true && \
-pip3 install -r requirements.txt;
-
-RUN true && \
-pip3 install lolcat boxes flask requests;
+pip3 install boxes flask lolcat requests -r requirements.txt;
 
 RUN true && \
  echo "/root/hackingtool/" > /home/hackingtoolpath.txt;


### PR DESCRIPTION
Now that pip has a real dependency resolver, use it to install ALL pip dependencies in a single Docker layer.
* https://pip.pypa.io/en/stable/topics/dependency-resolution
* https://docs.docker.com/storage/storagedriver/#images-and-layers