### PR TITLE
Use Python os.makedirs() instead of os.makedir()

### DIFF
--- a/hackingtool.py
+++ b/hackingtool.py
@@ -102,8 +102,7 @@ if __name__ == "__main__":
 
             with open(fpath) as f:
                 archive = f.readline()
-                if not os.path.exists(archive):
-                    os.mkdir(archive)
+                os.mkdirs(archive, exist_ok=True)
                 os.chdir(archive)
                 AllTools().show_options()
 


### PR DESCRIPTION
Fixes #384 

[`os.makedir()`](https://docs.python.org/3/library/os.html#os.makedir) is raising `FileNotFoundError` because a parent directory in the path `archive` does not exist so let's use [`os.makedirs()`](https://docs.python.org/3/library/os.html#os.makedirs) which will create any missing parent directories.