### PR TITLE
Do not hardcode the home directory

### DIFF
--- a/hackingtool.py
+++ b/hackingtool.py
@@ -74,7 +74,7 @@ class AllTools(HackingToolsCollection):
 if __name__ == "__main__":
     try:
         if system() == 'Linux':
-            fpath = "~/hackingtoolpath.txt"
+            fpath = os.path.expanduser("~/hackingtoolpath.txt")
             if not os.path.exists(fpath):
                 os.system('clear')
                 # run.menu()

--- a/hackingtool.py
+++ b/hackingtool.py
@@ -74,7 +74,7 @@ class AllTools(HackingToolsCollection):
 if __name__ == "__main__":
     try:
         if system() == 'Linux':
-            fpath = "/home/hackingtoolpath.txt"
+            fpath = "~/hackingtoolpath.txt"
             if not os.path.exists(fpath):
                 os.system('clear')
                 # run.menu()


### PR DESCRIPTION
Fixes #369

Use [`os.path.expanduser()`](https://docs.python.org/3/library/os.path.html#os.path.expanduser) to avoid hardcoding the home directory.