### PR TITLE
Fix AttributeError: module 'os' has no attribute 'mkdirs'.

### DIFF
--- a/hackingtool.py
+++ b/hackingtool.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
             with open(fpath) as f:
                 archive = f.readline()
-                os.mkdirs(archive, exist_ok=True)
+                os.makedirs(archive, exist_ok=True)
                 os.chdir(archive)
                 AllTools().show_options()
 


### PR DESCRIPTION
Fixes #390
Fixes #392
```
Traceback (most recent call last):
File "/usr/share/hackingtool/hackingtool.py", line 105, in
os.mkdirs(archive, exist_ok=True)
^^^^^^^^^
AttributeError: module 'os' has no attribute 'mkdirs'.
```
https://docs.python.org/3/library/os.html#os.makedirs

@Z4nzu This is an **urgent** fix.  Sorry about this typo.