### PR TITLE
Fix AttributeError in hackingtool.py

### DIFF
--- a/hackingtool.py
+++ b/hackingtool.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
             with open(fpath) as f:
                 archive = f.readline()
-                os.mkdirs(archive, exist_ok=True)
+                os.makedirs(archive, exist_ok=True)
                 os.chdir(archive)
                 AllTools().show_options()
 


### PR DESCRIPTION
This PR fixes an AttributeError in hackingtool.py where the non-existent os.mkdirs method was being called, resulting in a crash. The correct method, os.makedirs, has been used in place of os.mkdirs.

**Changes:**
- Changed `os.mkdirs` to `os.makedirs` in line 105 of hackingtool.py

**This fix ensures that the directory creation process works as expected, allowing the hacking tool to function properly.**