### PR TITLE
Test install, run, uninstall

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         commands:
           # Enter hackingtool starting from the main menu with \n as the delimiter. 
-          - '17\n0\n1\n\n99\n99'  # Install, run, update, update system,      press ENTER to continue, back to main menu, quit
-          - '17\n0\n2\n\n99\n99'  # Install, run, update, update hackingtool, press ENTER to continue, back to main menu, quit
-          - '17\n1\n1\n\n99'  # Install, run, uninstall, press ENTER to continue, quit
+          - '17\n0\n1\n\n99\n99\n99'  # Install, run, update, update system,      press ENTER to continue, back to main menu, quit
+          - '17\n0\n2\n\n99\n99\n99'  # Install, run, update, update hackingtool, press ENTER to continue, back to main menu, quit
+          - '17\n1\n1\n\n99\n99'  # Install, run, uninstall, press ENTER to continue, quit
           - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         commands:
           # Enter hackingtool starting from the main menu with \n as the delimiter. 
-          - '17\n0\n1\n\n99\n99\n99'  # Install, run, update, update system,      press ENTER to continue, back to main menu, quit
-          - '17\n0\n2\n\n99\n99\n99'  # Install, run, update, update hackingtool, press ENTER to continue, back to main menu, quit
-          # - '17\n1\n1\n'  # Install, run, uninstall, press ENTER to continue
+          - "17\n0\n1\n\n99\n99\n99"  # Install, run, update, update system,      press ENTER to continue, back to main menu, quit
+          - "17\n0\n2\n\n99\n99\n99"  # Install, run, update, update hackingtool, press ENTER to continue, back to main menu, quit
+          # - "17\n1\n1\n"  # Install, run, uninstall, press ENTER to continue
           - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,7 +14,8 @@ jobs:
       matrix:
         commands:
           # Enter hackingtool starting from the main menu with \n as the delimiter. 
-          - "17"  # Install, run, uninstall
+          - "17\n0"  # Install, run, update
+          - "17\n1"  # Install, run, uninstall
           - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,8 +14,9 @@ jobs:
       matrix:
         commands:
           # Enter hackingtool starting from the main menu with \n as the delimiter. 
-          - "17\n0"  # Install, run, update
-          - "17\n1"  # Install, run, uninstall
+          - "17\n0\n1"  # Install, run, update, update system
+          - "17\n0\n2"  # Install, run, update, update hackingtool
+          - "17\n1\n"  # Install, run, uninstall, press ENTER to continue
           - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -5,10 +5,19 @@ on:
   push:
     branches: [master]
 jobs:
-  install:
+  test_install:
     runs-on: ubuntu-latest
     env:
       TERM: "linux"
+    strategy:
+      fail-fast: false
+      matrix:
+        commands:
+          # Enter hackingtool starting from the main menu with \n as the delimiter. 
+          - '17\n0\n1\n\n99\n99'  # Install, run, update, update system,      press ENTER to continue, back to main menu, quit
+          - '17\n0\n2\n\n99\n99'  # Install, run, update, update hackingtool, press ENTER to continue, back to main menu, quit
+          - '17\n1\n1\n\n99'  # Install, run, uninstall, press ENTER to continue, quit
+          - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -19,40 +28,9 @@ jobs:
       - run: pwd && ls -hal
       - run: sudo ./install.sh 1
       - run: pwd && ls -hal
-      # Typing "1" will allow us to manually enter the filepath to hackingtool
+      # Typing "1" will allow us to manually enter the filepath to hackingtool.
       # Provide the filepath ${HOME}/work/hackingtool/hackingtool
-      # Typing "99" will quit hackingtool
-      - run: echo -e "1\n${HOME}/work/hackingtool/hackingtool\n99\n" | hackingtool
-      - run: pwd && ls -hal
-
-  test_install:
-    runs-on: ubuntu-latest
-    needs: install
-    env:
-      TERM: "linux"
-    strategy:
-      fail-fast: false
-      matrix:
-        commands:
-          # Enter hackingtool starting from the main menu with \n as the delimiter. 
-          - '17\n0\n1\n\n99'  # Install, run, update, update system, press ENTER to continue
-          - '17\n0\n2\n\n99'  # Install, run, update, update hackingtool, press ENTER to continue
-          - '17\n1\n1\n\n99'  # Install, run, uninstall, press ENTER to continue
-          - "99"  # Install, run, quit
-    steps:
-      #- uses: actions/checkout@v3
-      #- uses: actions/setup-python@v4
-      #  with:
-      #    python-version: 3.x
-      #    cache: 'pip'
-      #- run: pip install --upgrade pip
-      #- run: pwd && ls -hal
-      #- run: sudo ./install.sh 1
-      - run: hackingtool | true
-      - run: pwd && ls -hal
-      # Typing "1" will allow us to manually enter the filepath to hackingtool
-      # Provide the filepath ${HOME}/work/hackingtool/hackingtool
-      # Type the matrix.commands
+      # Type the matrix.commands.
       - run: echo -e "1\n${HOME}/work/hackingtool/hackingtool\n${{ matrix.commands }}\n" | hackingtool
       - run: pwd && ls -hal
 

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         commands:
           # Enter hackingtool starting from the main menu with \n as the delimiter. 
-          - "17\n0\n1\n"  # Install, run, update, update system, press ENTER to continue
-          - "17\n0\n2\n"  # Install, run, update, update hackingtool, press ENTER to continue
-          - '17\n1\n'  # Install, run, uninstall, press ENTER to continue
+          - "17\n0\n1\n99"  # Install, run, update, update system, press ENTER to continue
+          - "17\n0\n2\n99"  # Install, run, update, update hackingtool, press ENTER to continue
+          - '17\n1\n99'  # Install, run, uninstall, press ENTER to continue
           - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -5,19 +5,10 @@ on:
   push:
     branches: [master]
 jobs:
-  test_install:
+  install:
     runs-on: ubuntu-latest
     env:
       TERM: "linux"
-    strategy:
-      fail-fast: false
-      matrix:
-        commands:
-          # Enter hackingtool starting from the main menu with \n as the delimiter. 
-          - "17\n0\n1\n99"  # Install, run, update, update system, press ENTER to continue
-          - "17\n0\n2\n99"  # Install, run, update, update hackingtool, press ENTER to continue
-          - '17\n1\n99'  # Install, run, uninstall, press ENTER to continue
-          - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -27,6 +18,37 @@ jobs:
       - run: pip install --upgrade pip
       - run: pwd && ls -hal
       - run: sudo ./install.sh 1
+      - run: pwd && ls -hal
+      # Typing "1" will allow us to manually enter the filepath to hackingtool
+      # Provide the filepath ${HOME}/work/hackingtool/hackingtool
+      # Typing "99" will quit hackingtool
+      - run: echo -e "1\n${HOME}/work/hackingtool/hackingtool\n99\n" | hackingtool
+      - run: pwd && ls -hal
+
+  test_install:
+    runs-on: ubuntu-latest
+    needs: install
+    env:
+      TERM: "linux"
+    strategy:
+      fail-fast: false
+      matrix:
+        commands:
+          # Enter hackingtool starting from the main menu with \n as the delimiter. 
+          - '17\n0\n1\n\n99'  # Install, run, update, update system, press ENTER to continue
+          - '17\n0\n2\n\n99'  # Install, run, update, update hackingtool, press ENTER to continue
+          - '17\n1\n1\n\n99'  # Install, run, uninstall, press ENTER to continue
+          - "99"  # Install, run, quit
+    steps:
+      #- uses: actions/checkout@v3
+      #- uses: actions/setup-python@v4
+      #  with:
+      #    python-version: 3.x
+      #    cache: 'pip'
+      #- run: pip install --upgrade pip
+      #- run: pwd && ls -hal
+      #- run: sudo ./install.sh 1
+      - run: hackingtool | true
       - run: pwd && ls -hal
       # Typing "1" will allow us to manually enter the filepath to hackingtool
       # Provide the filepath ${HOME}/work/hackingtool/hackingtool

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -16,7 +16,7 @@ jobs:
           # Enter hackingtool starting from the main menu with \n as the delimiter. 
           - '17\n0\n1\n\n99\n99\n99'  # Install, run, update, update system,      press ENTER to continue, back to main menu, quit
           - '17\n0\n2\n\n99\n99\n99'  # Install, run, update, update hackingtool, press ENTER to continue, back to main menu, quit
-          - '17\n1\n1\n\n99\n99'  # Install, run, uninstall, press ENTER to continue, quit
+          # - '17\n1\n1\n'  # Install, run, uninstall, press ENTER to continue
           - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -13,11 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         commands:
-          # Typing "1" will allow us to manually enter a path.
-          # Provide a path to a writable directory: /tmp
-          # Typing "99" will quit hackingtool. 
-          - "1\n${HOME}/hackingtool.config\n99\n"  # Install, run, quit
-          - "1\n/tmp/hackingtool\n17\n"  # Install, run, uninstall
+          # Enter hackingtool starting from the main menu with \n as the delimiter. 
+          - "17"  # Install, run, uninstall
+          - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -28,6 +26,9 @@ jobs:
       - run: pwd && ls -hal
       - run: sudo ./install.sh 1
       - run: pwd && ls -hal
-      - run: echo -e ${{ matrix.commands }} | hackingtool
+      # Typing "1" will allow us to manually enter the filepath to hackingtool
+      # Provide the filepath ${HOME}/work/hackingtool/hackingtool
+      # Type the matrix.commands
+      - run: echo -e "1\n${HOME}/work/hackingtool/hackingtool\n${{ matrix.commands }}\n" | hackingtool
       - run: pwd && ls -hal
 

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         commands:
           # Enter hackingtool starting from the main menu with \n as the delimiter. 
-          - "17\n0\n1"  # Install, run, update, update system
-          - "17\n0\n2"  # Install, run, update, update hackingtool
-          - "17\n1\n"  # Install, run, uninstall, press ENTER to continue
+          - "17\n0\n1\n"  # Install, run, update, update system, press ENTER to continue
+          - "17\n0\n2\n"  # Install, run, update, update hackingtool, press ENTER to continue
+          - '17\n1\n'  # Install, run, uninstall, press ENTER to continue
           - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -9,6 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TERM: "linux"
+    strategy:
+      fail-fast: false
+      matrix:
+        commands:
+          # Typing "1" will allow us to manually enter a path.
+          # Provide a path to a writable directory: /tmp
+          # Typing "99" will quit hackingtool. 
+          - "1\n${HOME}\n99\n"  # Install, run, quit
+          - "1\n/tmp\n17\n"  # Install, run, uninstall
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -19,9 +28,6 @@ jobs:
       - run: pwd && ls -hal
       - run: sudo ./install.sh 1
       - run: pwd && ls -hal
-      # Typing "1" will allow us to manually enter a path.
-      # Provide a path to a writable directory: /home/runner/work/hackingtool/hackingtool
-      # Typing "99" will quit hackingtool. 
-      - run: echo -e "1\n/home/runner/work/hackingtool/hackingtool\n99\n" | hackingtool
+      - run: echo -e ${{ matrix.commands }} | hackingtool
       - run: pwd && ls -hal
 

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -16,8 +16,8 @@ jobs:
           # Typing "1" will allow us to manually enter a path.
           # Provide a path to a writable directory: /tmp
           # Typing "99" will quit hackingtool. 
-          - "1\n${HOME}\n99\n"  # Install, run, quit
-          - "1\n/tmp\n17\n"  # Install, run, uninstall
+          - "1\n${HOME}/hackingtool.config\n99\n"  # Install, run, quit
+          - "1\n/tmp/hackingtool\n17\n"  # Install, run, uninstall
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/tools/tool_manager.py
+++ b/tools/tool_manager.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import os
+import sys
 from time import sleep
 
 from core import HackingTool
@@ -53,9 +54,8 @@ class UninstallTool(HackingTool):
                   "sudo rm -rf /usr/share/doc/hackingtool/;"
                   "cd /etc/;"
                   "sudo rm -rf /etc/hackingtool/;")
-        print("\nHackingtool Successfully Uninstalled..")
-        print("Happy Hacking..!!")
-        sleep(1)
+        print("\nHackingtool Successfully Uninstalled... Goodbye.")
+        sys.exit()
 
 
 class ToolManager(HackingToolsCollection):


### PR DESCRIPTION
This is _finally_ ready for review...
```
    strategy:
      fail-fast: false
      matrix:
        commands:
          # Enter hackingtool starting from the main menu with \n as the delimiter. 
          - '17\n0\n1\n\n99\n99\n99'  # Install, run, update, update system,      press ENTER to continue, back to main menu, quit
          - '17\n0\n2\n\n99\n99\n99'  # Install, run, update, update hackingtool, press ENTER to continue, back to main menu, quit
          # - '17\n1\n1\n'  # Install, run, uninstall, press ENTER to continue
          - "99"  # Install, run, quit
```
allows us to walk up and down hackingtool's menu hierarchy to try out different commands.

I will enable the commented-out uninstall test in a follow-up pull request after this one lands.

That test needs the change made to `tools/tool_manager.py` where after hackingtool has been successfully uninstalled, we do not try to go back to the main menu because it no longer exists!

When merging this, please do __Squash & Merge__...
![Screenshot 2023-07-19 at 18 34 55](https://github.com/Z4nzu/hackingtool/assets/3709715/a4f83dfc-5a7a-4804-8e4f-3437ad17f9ec)
...to keep all these little commits out of your repo.