### PR TITLE
Add test for install, run, and uninstall

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -16,7 +16,7 @@ jobs:
           # Enter hackingtool starting from the main menu with \n as the delimiter. 
           - "17\n0\n1\n\n99\n99\n99"  # Install, run, update, update system,      press ENTER to continue, back to main menu, quit
           - "17\n0\n2\n\n99\n99\n99"  # Install, run, update, update hackingtool, press ENTER to continue, back to main menu, quit
-          # - "17\n1\n1\n"  # Install, run, uninstall, press ENTER to continue
+          - "17\n1\n1\n"  # Install, run, uninstall, press ENTER to continue
           - "99"  # Install, run, quit
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
```diff
-          # - "17\n1\n1\n"  # Install, run, uninstall, press ENTER to continue
+          - "17\n1\n1\n"  # Install, run, uninstall, press ENTER to continue
```
We can uncomment/enable this test now that #394 has been merged.

It would be interesting to add more of these tests to run some of the tools inside the GitHub Actions containers.