### PR TITLE
Optimized Dockerfile for layer cache and moved all the installations …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,12 @@
-FROM kalilinux/kali-rolling
-
+FROM kalilinux/kali-rolling:latest
 RUN apt-get update && \
-apt-get install -y git python3-pip figlet sudo;
-
-#Install packages dependencies
-RUN true && \
-apt-get install -y boxes php curl xdotool wget;
+    apt-get install -y git python3-pip figlet sudo && \
+    apt-get install -y boxes php curl xdotool wget
 
 WORKDIR /root/hackingtool
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir boxes flask lolcat requests -r requirements.txt
 COPY . .
-
-RUN true && \
-pip3 install boxes flask lolcat requests -r requirements.txt;
-
-RUN true && \
- echo "/root/hackingtool/" > /home/hackingtoolpath.txt;
-
+RUN true && echo "/root/hackingtool/" > /home/hackingtoolpath.txt;
 EXPOSE 1-65535
-
 ENTRYPOINT ["python3", "/root/hackingtool/hackingtool.py"]

--- a/README.md
+++ b/README.md
@@ -240,13 +240,34 @@
 
 ## Use image with Docker
 
-### Run in one click
-`docker run -it vgpastor/hackingtool`
+### Create Docker Image
+- Create the docker image 
 
-### Build locally
-`docker-compose build`
+```bash
+docker buitl -t vgpastor/hackingtool .
+```
 
-`docker-compose run hackingtool`
+### Run as container 
+
+```bash
+docker-compose up -d
+```
+
+### Interact with terminal
+
+- Get into the container 
+```bash
+docker exec -it hackingtool bash
+```
+**OUTPUT:**
+```bash
+Select Best Option : 
+
+              [1] Kali Linux / Parrot-Os (apt)
+              [2] Arch Linux (pacman)
+              [0] Exit 
+```
+Enter the options and continue.
 
 - If need open other ports you can edit the docker-compose.yml file
 - Volumes are mounted in the container to persist data and can share files between the host and the container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 version: "3.9"
 services:
   hackingtool:
-    build: .
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
+    image: vgpastor/hackingtool
+    container_name: hackingtool
+    stdin_open: true
+    tty: true
     volumes:
       - .:/root/hackingtool
     ports:


### PR DESCRIPTION
Dockerfile layers cache for apt packages, for every code change we don't need to install apt package. 