### PR TITLE
Issue #415: Added code to access parent directory for fixing import error for core.py

### DIFF
--- a/tools/forensic_tools.py
+++ b/tools/forensic_tools.py
@@ -1,6 +1,13 @@
 # coding=utf-8
 import os
 
+import sys
+
+# Fetching parent directory for importing core.py
+current_dir = os.path.dirname(__file__)
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
 from core import HackingTool
 from core import HackingToolsCollection
 


### PR DESCRIPTION
The initial code was trying to import core.py current directory, which drew error as it is not present in current directory, instead in parent directory. So added code to import core.py from paarent directory.
Fixed Import Error: Issue #415