### PR TITLE
Added a new link for image of Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@
 ![](https://github.com/Z4nzu/hackingtool/blob/master/images/A2.png)
 ![](https://github.com/Z4nzu/hackingtool/blob/master/images/A4.png)
 
-### Installation For Linux <img src="https://upafdafdload.wikimedia.org/wikipedia/commons/f/f1/Icons8_flat_linux.svg" alt="linux" width="30" height="30"/></p><p align="center">
+### Installation For Linux <img src="https://upload.wikimedia.org/wikipedia/commons/d/d8/Tux-flat.svg" alt="linux" width="30" height="30"/></p><p align="center">
 ### !! RUN HACKINGTOOL AS ROOT !! 
 
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@
 ![](https://github.com/Z4nzu/hackingtool/blob/master/images/A2.png)
 ![](https://github.com/Z4nzu/hackingtool/blob/master/images/A4.png)
 
-## Installation For Linux <img src="https://konpa.github.io/devicon/devicon.git/icons/linux/linux-original.svg" alt="linux" width="25" height="25"/></p><p align="center">
+## Installation For Linux <img src="https://upload.wikimedia.org/wikipedia/commons/f/f1/Icons8_flat_linux.svg" alt="linux" width="25" height="25"/></p><p align="center">
 
 
 ### !! RUN HACKINGTOOL AS ROOT !! 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@
 ![](https://github.com/Z4nzu/hackingtool/blob/master/images/A2.png)
 ![](https://github.com/Z4nzu/hackingtool/blob/master/images/A4.png)
 
-### Installation For Linux <img src="https://upload.wikimedia.org/wikipedia/commons/f/f1/Icons8_flat_linux.svg" alt="linux" width="30" height="30"/></p><p align="center">
+### Installation For Linux <img src="https://upafdafdload.wikimedia.org/wikipedia/commons/f/f1/Icons8_flat_linux.svg" alt="linux" width="30" height="30"/></p><p align="center">
 ### !! RUN HACKINGTOOL AS ROOT !! 
 
 

--- a/README.md
+++ b/README.md
@@ -209,9 +209,7 @@
 ![](https://github.com/Z4nzu/hackingtool/blob/master/images/A2.png)
 ![](https://github.com/Z4nzu/hackingtool/blob/master/images/A4.png)
 
-## Installation For Linux <img src="https://upload.wikimedia.org/wikipedia/commons/f/f1/Icons8_flat_linux.svg" alt="linux" width="25" height="25"/></p><p align="center">
-
-
+### Installation For Linux <img src="https://upload.wikimedia.org/wikipedia/commons/f/f1/Icons8_flat_linux.svg" alt="linux" width="30" height="30"/></p><p align="center">
 ### !! RUN HACKINGTOOL AS ROOT !! 
 
 


### PR DESCRIPTION
This resolves #420 
In the current version of README.md file the link for the image of linux is broken. This was fixed in this pr 

![Screenshot 2023-10-25 231240](https://github.com/Z4nzu/hackingtool/assets/70795867/401badd9-2528-4434-a89b-7c90d0abf8ce)
