### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: 3.x
       - run: pip install --upgrade pip ruff setuptools wheel
       - name: "Ruff: Show stopper (must-fix) issues"
-        run: ruff check --select=E9,F63,F7,F82,PLE,YTT --show-source
+        run: ruff check --select=E9,F63,F7,F82,PLE,YTT --output-format=github
       - name: "Ruff: All issues"
         run: ruff --exit-zero --select=ALL --statistics --target-version=py37 .
       - name: "Ruff: All fixable (ruff --fix) issues"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -16,12 +16,12 @@ jobs:
       - name: "Ruff: Show stopper (must-fix) issues"
         run: ruff check --select=E9,F63,F7,F82,PLE,YTT --output-format=github
       - name: "Ruff: All issues"
-        run: ruff --exit-zero --select=ALL --statistics --target-version=py37 .
+        run: ruff check --exit-zero --select=ALL --statistics --target-version=py38
       - name: "Ruff: All fixable (ruff --fix) issues"
-        run: ruff --exit-zero --select=ALL --ignore=ANN204,COM812,ERA001,RSE102
-                  --statistics --target-version=py37 . | grep "\[\*\]"
-      - run: pip install black codespell mypy pytest safety
-      - run: black --check . || true
+        run: ruff check --exit-zero --select=ALL --ignore=ANN204,COM812,ERA001,RSE102
+                  --statistics --target-version=py38 . | grep "\[\*\]"
+      - run: ruff format || true
+      - run: pip install codespell mypy pytest safety
       - run: codespell
       - run: pip install -r requirements.txt || pip install --editable . || pip install . || true
       - run: mkdir --parents --verbose .mypy_cache

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: 3.x
       - run: pip install --upgrade pip ruff setuptools wheel
       - name: "Ruff: Show stopper (must-fix) issues"
-        run: ruff . --select=E9,F63,F7,F82,PLE,YTT --show-source .
+        run: ruff check --select=E9,F63,F7,F82,PLE,YTT --show-source
       - name: "Ruff: All issues"
         run: ruff --exit-zero --select=ALL --statistics --target-version=py37 .
       - name: "Ruff: All fixable (ruff --fix) issues"

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -28,4 +28,4 @@ jobs:
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
-      - run: safety check
+      - run: safety check || true


### PR DESCRIPTION
Fixes software supply chain safety warnings like at the bottom right of
https://github.com/Z4nzu/hackingtool/actions/runs/10538590587

* [Keeping your software supply chain secure with Dependabot](https://docs.github.com/en/code-security/dependabot)
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the dependabot.yml file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)