### PR TITLE
Added functionality to run hackingtool on Windows using wsl with automated setup.

### DIFF
--- a/hackingtool_windows_setup.bat
+++ b/hackingtool_windows_setup.bat
@@ -1,0 +1,32 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Check if WSL is installed
+wsl --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Installing WSL...
+    wsl --install
+    echo WSL installation complete. Please restart your computer and run this script again.
+    exit /b
+)
+
+REM Check if Ubuntu is installed
+wsl -l -v | findstr /i "Ubuntu" >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Installing Ubuntu...
+	
+REM Display instructions for the user
+echo.
+echo The following commands will install and run the Hackingtool in WSL:
+echo.
+echo "  sudo apt update && sudo apt upgrade -y && sudo apt install -y git docker.io docker-compose && rm -rf hackingtool && git clone  https://github.com/Z4nzu/hackingtool.git && cd hackingtool && chmod -R 755 . && sudo bash install.sh && sudo hackingtool  "
+echo.
+echo Please copy the above command and paste (or right click) into the Ubuntu terminal. [Without quotes]
+echo.
+	
+    wsl --install -d Ubuntu
+    echo Ubuntu installation complete. Please restart your computer and run this script again.
+    exit /b
+)
+
+pause


### PR DESCRIPTION
Added Batch file to install Ubuntu using wsl in windows and giving command to be pasted on ubuntu terminal which will be there to run the hackingtool.

Just:
1. Open cmd as administrator 
2. Move to path where setup file is stored by using cd
3. Type hackingtool_windows_setup.bat, Hit enter.
4. Wsl and Ubuntu will be downloaded and installed. Restart the pc when message is shown.
5. Run the script again
6. Setup ubuntu by assigning username and password. Then again run the script.
7. Paste the command shown in message in ubuntu terminal. And BOOM you can use hackingtool on Windows.

This will make the project much more accessible and much more flexible. Will attract even those users who don't have unix based systems installed. Will make project scalable.

And Thank you for such an awesome toolkit I was looking for something like that from a long time. This repo deserves all the traction it is getting and more. 

I know my script can be improved a lot but it works right now and I hope you'll appreciate this PR for the idea.

Thank you.