### PR TITLE
Update Dockerfile to use Python virtual environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,23 @@
 FROM kalilinux/kali-rolling:latest
+
 RUN apt-get update && \
-    apt-get install -y git python3-pip figlet sudo && \
-    apt-get install -y boxes php curl xdotool wget
+    apt-get install -y git python3-pip python3-venv figlet sudo boxes php curl xdotool wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/hackingtool
+
 COPY requirements.txt ./
-RUN pip3 install --no-cache-dir boxes flask lolcat requests -r requirements.txt
+
+RUN python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip && \
+    /opt/venv/bin/pip install --no-cache-dir boxes flask lolcat requests -r requirements.txt
+
+ENV PATH="/opt/venv/bin:$PATH"
+
 COPY . .
-RUN true && echo "/root/hackingtool/" > /home/hackingtoolpath.txt;
+
+RUN true && echo "/root/hackingtool/" > /home/hackingtoolpath.txt
+
 EXPOSE 1-65535
+
 ENTRYPOINT ["python3", "/root/hackingtool/hackingtool.py"]


### PR DESCRIPTION
Fix the build error 

```
STEP 5/9: RUN pip3 install --no-cache-dir boxes flask lolcat requests -r requirements.txt
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Kali-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have pypy3-venv installed.

    If you wish to install a non-Kali-packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    For more information, refer to the following:
    * https://www.kali.org/docs/general-use/python3-external-packages/
    * /usr/share/doc/python3.13/README.venv

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
Error: building at STEP "RUN pip3 install --no-cache-dir boxes flask lolcat requests -r requirements.txt": while running runtime: exit status 1

```