### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,8 +8,8 @@ jobs:
   lint_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: pip install --upgrade pip ruff setuptools wheel

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -19,8 +19,8 @@ jobs:
           - "17\n1\n1\n"  # Install, run, uninstall, press ENTER to continue
           - "99"  # Install, run, quit
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
           cache: 'pip'


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/test_install.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/test_install.yml`
- Updated `actions/setup-python` from `v4` to `v6` in `.github/workflows/lint_python.yml`
- Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/lint_python.yml`
