### PR TITLE
fix: use [warning] markup for uninstall command output instead of [error]

### DIFF
--- a/core.py
+++ b/core.py
@@ -225,7 +225,7 @@ class HackingTool:
         if self.before_uninstall():
             if isinstance(self.UNINSTALL_COMMANDS, (list, tuple)):
                 for cmd in self.UNINSTALL_COMMANDS:
-                    console.print(f"[error]→ {cmd}[/error]")
+                    console.print(f"[warning]→ {cmd}[/warning]")
                     os.system(cmd)
         self.after_uninstall()
 


### PR DESCRIPTION
## Summary

Fixes inconsistent Rich markup in `core.py` where uninstall commands were displayed with `[error]` (red) style instead of `[warning]` (yellow), misleading users into thinking something went wrong.

## Change

| File | Line | Before | After |
|------|------|--------|-------|
| `core.py` | 228 | `console.print(f"[error]→ {cmd}[/error]")` | `console.print(f"[warning]→ {cmd}[/warning]")` |

## Why it matters

The `install()` method correctly uses `[warning]` (yellow) to display each command before running it — this is just an informational status, not an error.

The `uninstall()` method used `[error]` (red) for the same pattern, causing uninstall commands to appear as errors in the terminal. This confuses users who think the uninstall is failing when it is actually running normally.

Closes #662

---
*Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>*