### PR TITLE
[Fix] installer break during check_root on Windows

### DIFF
--- a/install.py
+++ b/install.py
@@ -225,15 +225,17 @@ def create_user_directories():
 # ── Entry point ────────────────────────────────────────────────────────────────
 
 def main():
-    check_root()
     console.clear()
+
+    check_os_compatibility()
+    check_root()
+
 
     console.print(Panel(
         Text(f"HackingTool Installer  {VERSION_DISPLAY}", style="bold magenta"),
         box=box.DOUBLE, border_style="bright_magenta",
     ))
 
-    check_os_compatibility()
 
     if not check_internet():
         sys.exit(1)


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

---

**Why should it be added?**
This will prevent break and issues being created by windows users since the Windows error message wont display if the installer break on the function before since `os.geteuid()` used in `check_root()` dont exist on Windows

I just swapped `check_os_compatibility `and `check_root`.

---

## Checklist

- [x] Title follows the format above
- [x] New tool class added to the correct `tools/*.py` file
- [x] `TITLE`, `DESCRIPTION`, `INSTALL_COMMANDS`, `RUN_COMMANDS`, `PROJECT_URL` all set
- [x] `SUPPORTED_OS` set correctly (`["linux"]` / `["linux", "macos"]`)
- [x] Tool added to the `TOOLS` list in the collection class at the bottom of the file
- [x] No new dependencies added to `requirements.txt` without discussion
- [x] Tested locally — install and run commands work
