### PR TITLE
fix(core): use [warning] markup in uninstall() to match install() style

### DIFF
--- a/core.py
+++ b/core.py
@@ -225,7 +225,7 @@ class HackingTool:
         if self.before_uninstall():
             if isinstance(self.UNINSTALL_COMMANDS, (list, tuple)):
                 for cmd in self.UNINSTALL_COMMANDS:
-                    console.print(f"[error]→ {cmd}[/error]")
+                    console.print(f"[warning]→ {cmd}[/warning]")
                     os.system(cmd)
         self.after_uninstall()
 


### PR DESCRIPTION
## Summary
Fixes #662

## What changed
In `core.py`, the `uninstall()` method was printing each command with `[error]` markup (red), 
while `install()` correctly uses `[warning]` markup (yellow) for the same purpose — 
displaying a command before running it.

## Why it matters
Red output signals an error to users. Seeing red text during a successful uninstall 
is confusing and alarming. This change makes the UX consistent and honest.

## Change
`core.py` line 228: `[error]` → `[warning]`

## Testing
- Visually verified that uninstall commands now display in yellow (warning style) 
  matching the install() method behavior.