### PR TITLE
Fix Rich markup error in PortScan prompt

### DIFF
--- a/tools/information_gathering.py
+++ b/tools/information_gathering.py
@@ -46,7 +46,7 @@ class PortScan(HackingTool):
     def run(self):
         clear_screen()
         console.print(Panel(Text(self.TITLE, justify="center"), style="bold magenta"))
-        target = Prompt.ask("[bold]Select a Target IP[/bold magenta]", default="", show_default=False)
+        target = Prompt.ask("[bold magenta]Select a Target IP[/bold magenta]", default="", show_default=False)
         subprocess.run(["sudo", "nmap", "-O", "-Pn", target])
 
 


### PR DESCRIPTION
## Summary
- Fixed mismatched Rich markup tags in `PortScan.run()` that caused a `MarkupError` at runtime
- Opening tag `[bold]` didn't match closing tag `[/bold magenta]` — updated to `[bold magenta]...[/bold magenta]`

## Test plan
- [ ] Run the tool and select "Port Scanning" — the prompt should display without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)